### PR TITLE
테스트/CI/README 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+NOTION_TOKEN=secret_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+NOTION_DATABASE_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+NOTION_VERSION=2022-06-28
+PORT=8080

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: true
+
+      - name: Verify dependencies
+        run: go mod verify
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.out
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,160 +1,91 @@
 # crow
 
-A lightweight Go webhook server that automatically parses Korean card transaction messages and logs them to a Notion database.
+A webhook server that parses card payment SMS and auto-logs them to a Notion budget tracker.
 
-## Overview
+[![CI](https://github.com/nonasking/crow/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/nonasking/crow/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/nonasking/crow/branch/develop/graph/badge.svg)](https://codecov.io/gh/nonasking/crow)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/nonasking/crow)](go.mod)
 
-Crow receives SMS/web notification messages from Korean banks (Shinhan Card, Woori Bank) via a webhook, extracts transaction details using regex-based parsing, and creates expense records in a Notion database — eliminating manual expense tracking.
+## Why
 
+Manually adding each card transaction to my Notion budget page got old fast. The payment SMS already carries everything I need — amount, merchant, date — so the natural move is to parse it on arrival and write it straight to Notion.
+
+An SMS forwarder app on my phone POSTs the message to this server. A regex parser dispatches on issuer, extracts the fields, and creates a page via the Notion API. 30~40 manual entries per month, gone.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    SMS[Card payment SMS] --> FWD[SMS forwarder app]
+    FWD -- "POST /webhook" --> GIN[Gin server]
+    GIN --> P{ParseWebhookAuto<br/>issuer detection}
+    P -->|Shinhan| PS[parseShinhanCard]
+    P -->|Woori| PW[parseWooriCard]
+    PS --> N[Notion API]
+    PW --> N
+    N --> DB[(Notion DB<br/>budget tracker)]
 ```
-Card notification → POST /webhook → Parse → Notion DB record
-```
 
-## Features
+Three layers, separated by intent:
 
-- Auto-detects card type from raw notification text
-- Supports multiple Shinhan Card message formats
-- Supports Woori Bank notification format
-- Extracts amount, merchant, payment method, and date
-- Creates structured records in Notion with mapped properties
+- `internal/parser` — issuer-specific SMS parsers. Pure functions, no external dependencies.
+- `internal/notion` — Notion API client. Maps parsed fields to page properties and POSTs.
+- `internal/handler` — Gin handler. Wires the two together.
 
-## Requirements
+The handler stays thin so the parser can be unit-tested in isolation.
 
-- Go 1.24+
-- A [Notion integration](https://www.notion.so/my-integrations) with write access to your database
-- A Notion database with the properties described below
-
-## Installation
+## Quick start
 
 ```bash
-git clone https://github.com/go-jcklk/crow.git
-cd crow
-go mod download
+cp .env.example .env
+# fill in NOTION_TOKEN, NOTION_DATABASE_ID, NOTION_VERSION
+
+go run ./cmd/server
 ```
 
-## Configuration
+Defaults to port `8080`. Override with `PORT`.
 
-Create a `.env` file in the project root:
-
-```env
-NOTION_TOKEN=secret_xxxxxxxxxxxxxxxxxxxx
-NOTION_DATABASE_ID=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-NOTION_VERSION=2022-06-28
-PORT=8080  # optional, defaults to 8080
-```
-
-| Variable             | Description                          | Required |
-|----------------------|--------------------------------------|----------|
-| `NOTION_TOKEN`       | Notion integration secret token      | Yes      |
-| `NOTION_DATABASE_ID` | Target Notion database ID            | Yes      |
-| `NOTION_VERSION`     | Notion API version                   | Yes      |
-| `PORT`               | Server port (default: `8080`)        | No       |
-
-## Running
+Request shape:
 
 ```bash
-# Development
-go run ./cmd/server/main.go
-
-# Build and run
-go build -o crow ./cmd/server
-./crow
+curl -X POST http://localhost:8080/webhook \
+  -H "Content-Type: application/json" \
+  -d '{"message": "[Web발신]\n1차 민생회복 신한(4557)승인 강*성 16,980원 08/24 17:50 땀땀 잔액 0원"}'
 ```
 
-## API
+## Adding a new card issuer
 
-### `POST /webhook`
+Three places to touch:
 
-Receives a raw card notification message and creates a Notion record.
+1. Add `parseXxxCard(msg) (...)` in `internal/parser/message_parser.go`
+2. Add a switch arm to `ParseWebhookAuto`
+3. Add fixture cases to `internal/parser/message_parser_test.go`
 
-**Request**
+The handler and Notion client stay untouched by design.
 
-```json
-{
-  "message": "<raw card notification text>"
-}
-```
+## Tradeoffs
 
-**Response — success**
+- **Regex-based parser** — breaks if an issuer changes their SMS format (Shinhan did once, which is why there are dual old/new format branches). Mitigated by accumulating real SMS samples as fixtures in `*_test.go`. CI goes red before production does.
+- **Notion as the data store** — zero infra cost. In exchange, throughput is bounded by Notion's rate limit (~3 req/sec average), so concurrent bursts are a non-goal. Fine for personal use.
+- **Render free tier deploy** — 5~10s cold start. Hidden inside the natural delay between swiping a card and the SMS arriving, so it's not noticeable.
 
-```json
-{ "status": "success" }
-```
-
-**Response — error**
-
-```json
-{ "error": "<error description>" }
-```
-
-| Status | Meaning                                      |
-|--------|----------------------------------------------|
-| 200    | Record created successfully                  |
-| 400    | Invalid JSON or unsupported message format   |
-| 500    | Notion API error                             |
-
-## Supported Message Formats
-
-### Shinhan Card (Format 1)
+## Layout
 
 ```
-[Web발신]
-신한카드(4557)승인 강*성 2,400원(일시불)04/20 16:56 세븐일레븐영 누적1,427,265원
+cmd/server/        # entry point
+internal/
+  config/          # .env loading and validation
+  constants/       # issuer names, error messages
+  handler/         # /webhook handler
+  notion/          # Notion API client
+  parser/          # issuer-dispatching SMS parser + tests
+.github/workflows/ # CI
 ```
 
-### Shinhan Card (Format 2)
+## Testing
 
-```
-1차 민생회복 신한(4557)승인 강*성 16,980원 08/24 17:50 땀땀 잔액 0원
-```
-
-### Woori Bank
-
-```
-[Web발신]
-우리은행통장에서
-출금되었습니다
-12,000원
-04/21 14:30
-스타벅스
+```bash
+go test ./... -cover
 ```
 
-## Notion Database Schema
-
-The following properties must exist in your Notion database:
-
-| Property   | Type   | Description                       |
-|------------|--------|-----------------------------------|
-| `항목`     | Title  | Merchant name                     |
-| `소분류`   | Select | Sub-category (default: `미정산`)  |
-| `결제방식` | Select | Payment method (card company)     |
-| `날짜`     | Date   | Transaction date (`YYYY-MM-DD`)   |
-| `수입`     | Number | Income amount (default: `0`)      |
-| `지출`     | Number | Expense amount                    |
-| `대분류`   | Select | Main category (default: `미정산`) |
-| `비고`     | Text   | Notes (default: empty)            |
-
-## Project Structure
-
-```
-crow/
-├── cmd/server/
-│   └── main.go               # Entry point
-├── internal/
-│   ├── config/
-│   │   └── config.go         # Environment variable loading
-│   ├── constants/
-│   │   └── constants.go      # Card names, error messages
-│   ├── handler/
-│   │   └── webhook.go        # HTTP handler
-│   ├── notion/
-│   │   └── client.go         # Notion API client
-│   └── parser/
-│       └── message_parser.go # Card message parsing
-├── go.mod
-└── go.sum
-```
-
-## License
-
-MIT
+Core business logic (the parser) is covered by table-driven tests over real SMS fixtures — happy path and error cases per issuer.

--- a/internal/notion/client_test.go
+++ b/internal/notion/client_test.go
@@ -1,0 +1,53 @@
+package notion
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestFormatPaymentDate(t *testing.T) {
+	currentYear := time.Now().Year()
+	today := time.Now().Format("2006-01-02")
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "정상 MM/DD",
+			in:   "08/24",
+			want: fmt.Sprintf("%04d-08-24", currentYear),
+		},
+		{
+			name: "0 패딩 없는 한자리 월일",
+			in:   "3/5",
+			want: fmt.Sprintf("%04d-03-05", currentYear),
+		},
+		{
+			name: "빈 문자열은 오늘 날짜",
+			in:   "",
+			want: today,
+		},
+		{
+			name: "포맷 깨짐 → 오늘 날짜로 폴백",
+			in:   "abc",
+			want: today,
+		},
+		{
+			name: "구분자 부족 → 오늘 날짜로 폴백",
+			in:   "0824",
+			want: today,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatPaymentDate(tc.in)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/parser/message_parser_test.go
+++ b/internal/parser/message_parser_test.go
@@ -1,0 +1,92 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-jcklk/crow/internal/constants"
+)
+
+func TestParseWebhookAuto(t *testing.T) {
+	tests := []struct {
+		name        string
+		msg         string
+		wantAmount  int
+		wantPlace   string
+		wantCompany string
+		wantDate    string
+		wantErr     bool
+	}{
+		{
+			name:        "신한카드 신규 포맷",
+			msg:         "[Web발신]\n1차 민생회복 신한(4557)승인 강*성 16,980원 08/24 17:50 땀땀 잔액 0원",
+			wantAmount:  16980,
+			wantPlace:   "땀땀",
+			wantCompany: constants.CardCompanyShinhan,
+			wantDate:    "08/24",
+		},
+		{
+			name: "우리은행 체크카드",
+			msg: strings.Join([]string{
+				"[Web발신]",
+				"우리카드 승인",
+				"03/15 14:30",
+				"12,000원",
+				"스타벅스 강남점",
+				"누적 1,234,567원",
+			}, "\n"),
+			wantAmount:  12000,
+			wantPlace:   "스타벅스 강남점",
+			wantCompany: constants.CardCompanyWoori,
+			wantDate:    "03/15",
+		},
+		{
+			name:    "지원하지 않는 카드사",
+			msg:     "[Web발신]\nKB국민카드 결제 알림 1,000원",
+			wantErr: true,
+		},
+		{
+			name:    "신한 포맷 일부 누락 (금액 없음)",
+			msg:     "[Web발신]\n신한카드(4557)승인 강*성",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			amount, place, company, date, err := ParseWebhookAuto(tc.msg)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("에러 기대했으나 nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("예상치 못한 에러: %v", err)
+			}
+			if amount != tc.wantAmount {
+				t.Errorf("amount: got %d, want %d", amount, tc.wantAmount)
+			}
+			if place != tc.wantPlace {
+				t.Errorf("place: got %q, want %q", place, tc.wantPlace)
+			}
+			if company != tc.wantCompany {
+				t.Errorf("company: got %q, want %q", company, tc.wantCompany)
+			}
+			if date != tc.wantDate {
+				t.Errorf("date: got %q, want %q", date, tc.wantDate)
+			}
+		})
+	}
+}
+
+func TestParseWebhookAutoLegacy(t *testing.T) {
+	msg := "[Web발신]\n1차 민생회복 신한(4557)승인 강*성 16,980원 08/24 17:50 땀땀 잔액 0원"
+	amount, place, company, err := ParseWebhookAutoLegacy(msg)
+	if err != nil {
+		t.Fatalf("예상치 못한 에러: %v", err)
+	}
+	if amount != 16980 || place != "땀땀" || company != constants.CardCompanyShinhan {
+		t.Errorf("got (%d, %q, %q), want (16980, 땀땀, %q)", amount, place, company, constants.CardCompanyShinhan)
+	}
+}


### PR DESCRIPTION
## Summary

- 파서·노션 클라이언트 단위 테스트 추가 (parser 73%, notion 48% 커버)
- GitHub Actions CI 추가 (`go vet` + `go build` + `go test -race` + Codecov 업로드)
- README 재작성 — Why / mermaid 아키텍처 / Quick start / 카드사 추가 가이드 / 트레이드오프
- `.env.example` 추가

## Test plan

- [x] 로컬에서 `go test ./... -race` 전부 통과
- [x] `go vet ./...` clean
- [x] `go build ./...` 성공
- [x] Push 후 GitHub Actions에서 동일하게 초록불 확인
- [x] (선택) Codecov 활성화 후 뱃지 표시 확인